### PR TITLE
newval had undefined value in some cases

### DIFF
--- a/jquery.mask.js
+++ b/jquery.mask.js
@@ -225,7 +225,7 @@
                     typeof options.onKeyPress == "function")
                         options.onKeyPress(newVal, e, $el, options);
 
-                if (options.onComplete && e.isTrigger === undefined &&
+                if (options.onComplete && e.isTrigger === undefined && newVal &&
                     newVal.length === mask.length && typeof options.onComplete == "function")
                         options.onComplete(newVal, e, $el, options);
             }


### PR DESCRIPTION
Hi, i discover that when selecting the whole text and deleting it with the "del" key or when pressing "del" multiple times deleting text from start to end, sometimes this method would break by saying that newVal was undefined. (Im using VisualStudio for debbuging and this makes noise, maybe using Chrome's debugger you can't even see this error or it's hidden somewhere and doesn't make much noise).
This is a quickfix cause i don't have a lot of time right now to look into it or if this can be fixed a little bit more "clean".

Let me know if this is happening to you to.
Great library! thanks :+1: 
