### PR TITLE
Prevent TypeError

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
     };
 
     $(".sp_celphones").mask(SaoPauloCelphoneMask, { onKeyPress: function(phone, e, currentField, options){
-      $(currentField).mask(SaoPauloCelphoneMask(phone), options);
+      if (phone) $(currentField).mask(SaoPauloCelphoneMask(phone), options);
     }});
 
     $(".bt-mask-it").click(function(){


### PR DESCRIPTION
Stop throwing errors (Cannot call method 'match' of undefined) when typing non-numeric characters.
