### PR TITLE
Add getTypedValue  (Value without mask)

### DIFF
--- a/jquery.mask.js
+++ b/jquery.mask.js
@@ -237,6 +237,11 @@
           __p.setVal(__p.removeMaskChars(__p.getVal()));
           $el.removeAttr('maxlength');
         };
+        
+        //get value without mask
+        plugin.getTypedValue = function() {
+          return __p.removeMaskChars(__p.getVal());
+        };
 
         plugin.init();
     };


### PR DESCRIPTION
I didn't find a method to get the value without mask, this solved my problem.

Thanks for the plugin, it was hard to find something that really works on mobile.
