### PR TITLE
Dirty fix for masks not completing with a literal

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jQuery-Mask-Plugin",
-  "version": "1.4.1.1",
+  "version": "1.4.1",
   "main": "jquery.mask.min.js",
   "ignore": [
     "deploy.rb",

--- a/jquery.mask.js
+++ b/jquery.mask.js
@@ -1,6 +1,6 @@
  /**
  * jquery.mask.js
- * @version: v1.4.1.1
+ * @version: v1.4.1
  * @author: Igor Escobar
  *
  * Created by Igor Escobar on 2012-03-10. Please report any bug at http://blog.igorescobar.com

--- a/mask.jquery.json
+++ b/mask.jquery.json
@@ -8,7 +8,7 @@
     "form",
     "input"
   ],
-  "version": "1.4.1.1",
+  "version": "1.4.1",
   "author": {
     "name": "Igor Escobar",
     "url": "https://github.com/igorescobar/jQuery-Mask-Plugin/blob/master/README.md"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jQuery-Mask-Plugin",
-  "version": "1.4.1.1",
+  "version": "1.4.1",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-qunit": "*",


### PR DESCRIPTION
Whenever the mask would have a format like "(99)" and the user typed
"99", the resulting value would end up being "(99" intead of "(99)".

This is a quick and dirty fix and should be refactored. It seems to me
that the function "check()" that controls the loop in jquery.mask.js:165
could be rewritten to accomodate this logic, but a quick reading of the
code didn't let me visualize cases in which the expression `m < maskLen
&& v < valLen` would evaluate to `true && false`, hence the quick fix.

I've also added a couple of test cases.
