### PR TITLE
Dirty fix for masks not completing with a literal

### DIFF
--- a/jquery.mask.js
+++ b/jquery.mask.js
@@ -197,6 +197,11 @@
                         m += offset;
                     }
                 }
+                
+                if (maskLen == valLen + 1 && !jMask.translation[mask.charAt(lastMaskChar)]) {
+                    buf.push(mask.charAt(lastMaskChar));
+                }
+                
                 return buf.join("");
             },
             callbacks: function (e) {

--- a/test/jquery.mask.test.js
+++ b/test/jquery.mask.test.js
@@ -125,6 +125,12 @@ $(document).ready(function(){
       equal( typeTest("00/00/0"), "00/00/0");
       equal( typeTest("00/00/00"), "00/00/00");
     });
+    
+    test("Testing masks with a literal on the last char", function () {
+      testfield.mask("(99)");
+      
+      equal( typeTest("(99"), "(99)");
+    });
 
 
     module('Masks with numbers and especial characters');
@@ -298,6 +304,11 @@ $(document).ready(function(){
     equal(typeTest("123456"), "123456");
     equal(typeTest("12345"), "12345");
   });
+  test("Testing reversible masks with a literal on the last char", function () {
+      testfield.mask("(99)");
+      
+      equal( typeTest("(99"), "(99)");
+    });
 
   module('Removing mask');
 


### PR DESCRIPTION
Whenever the mask would have a format like "(99)" and the user typed
"99", the resulting value would end up being "(99" intead of "(99)".

This is a quick and dirty fix and should be refactored. It seems to me
that the function "check()" that controls the loop in jquery.mask.js:165
could be rewritten to accomodate this logic, but a quick reading of the
code didn't let me visualize cases in which the expression `m < maskLen
&& v < valLen` would evaluate to `true && false`, hence the quick fix.

I've also added a couple of test cases.
