### PR TITLE
the "drop" fix

### DIFF
--- a/jquery.mask.js
+++ b/jquery.mask.js
@@ -107,14 +107,14 @@
                     old_value = p.val();
                 });
                 el.on('keyup.mask', p.behaviour);
-                el.on("paste.mask", function() {
+                el.on("paste.mask drop.mask", function() {
                     setTimeout(function() {
                         el.keydown().keyup();
                     }, 100);
                 });
             },
             destroyEvents: function() {
-                el.off('keydown.mask keyup.mask paste.mask');
+                el.off('keydown.mask keyup.mask paste.mask drop.mask');
             },
             val: function(v) {
                 var isInput = el.is('input');


### PR DESCRIPTION
Was implemented to fix the following problem: 
while selecting some text, drag and drop over an input, this event will not fire for the existing "key" events, since it is a "mouse-event"
