### PR TITLE
Bug in calculating difference between mask characters between old and new field values

### DIFF
--- a/jquery.mask.js
+++ b/jquery.mask.js
@@ -128,9 +128,9 @@
                     el.data("changeCalled", true);
                 });
                 el.on("blur.mask", function(e){
-                    var el = $(e.target)
+                    var el = $(e.target);
                     if (el.prop("defaultValue") != el.val()) {
-                        el.prop("defaultValue", el.val())
+                        el.prop("defaultValue", el.val());
                         if(!el.data("changeCalled"))
                             el.trigger("change");
                     }
@@ -148,7 +148,7 @@
             },
             getMaskCharactersBeforeCount: function(index, onCleanVal) {
                 var count = 0;
-                for (var i = 0; i < index; i++) {
+                for (var i = 0; i < mask.length && i < index; i++) {
                     var translation = jMask.translation[mask.charAt(i)];
                     if (!translation) {
                         count++;

--- a/test/jquery.mask.test.js
+++ b/test/jquery.mask.test.js
@@ -107,7 +107,7 @@ $(document).ready(function(){
 
     test('When I typed a char thats the same as the mask char', function(){
       testfield.mask('00/00/0000');
-      
+
       equal( typeTest("00/"), "00/");
       equal( typeTest("00a"), "00/");
       equal( typeTest("00a00/00"), "00/00/00");
@@ -417,7 +417,6 @@ $(document).ready(function(){
     };
 
     testfield.on("change", function(e){
-      console.log("aaa");
       ok(true, "Change event!!");
     });
 


### PR DESCRIPTION
A problem was noticed with the calculation of the difference between new and old mask count. This resulted in the caret being placed incorrectly when a mask character was added.

Re-masking was also not calculating the caret correctly

This pull request should fix it.
