### PR TITLE
Use non-minified version in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "jQuery-Mask-Plugin",
   "version": "1.6.4",
-  "main": "jquery.mask.min.js",
+  "main": "jquery.mask.js",
   "ignore": [
     "deploy.rb",
     "jquery.mask.json",


### PR DESCRIPTION
I really love bower, with grunt I can run live server and see the code for better understood about the code of plugins. Code minified is horrible to read.
