### PR TITLE
Translation defaults pull

### DIFF
--- a/jquery.mask.js
+++ b/jquery.mask.js
@@ -293,7 +293,11 @@
                         } else if (translation.optional) {
                             m += offset;
                             v -= offset;
-                        }
+                        } else if (translation.defaults) {
+							buf[addMethod](translation.defaults);
+							m += offset;
+							v -= offset;
+						}
                         v += offset;
                     } else {
                         if (!skipMaskChars) {

--- a/test/jquery.mask.test.js
+++ b/test/jquery.mask.test.js
@@ -556,4 +556,15 @@ $(document).ready(function(){
     typeAndBlur(testfield, "1.000,00");
     equal( testfield.val(), "1.000,00" );
   });
+  
+  test("test the translation defaults",function(){
+    testfield.mask('99t00', {'translation': {'t': {pattern: /[:,\\.]/, defaults: ':'}}});
+
+	equal( typeTest('1'), '1');
+	equal( typeTest('13'), '13');
+	equal( typeTest('137'), '13:3');
+    equal( typeTest('1337'), '13:37');
+	equal( typeTest('6.66'), '6.66');
+    equal( typeTest(',42'), ',42');
+  });
 });


### PR DESCRIPTION
Added defaults option for translation. This should let the user type the mask without typing one of the characters in the pattern.

Original challenge here:
http://stackoverflow.com/q/24676645/1449624

Note: I'm new to github, I just want to improve jQuery mask plugin :+1:
