### PR TITLE
Needed to manually apply "data-mask" masks

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -436,6 +436,10 @@
         return this.data('mask').getCleanVal();
     };
 
+    $.applyMasksFromHTML = function() {
+      $(document).find($.jMaskGlobals.maskElements).filter(globals.dataMaskAttr).each(HTMLAttributes);
+    }
+
     var globals = {
         maskElements: 'input,td,span,div',
         dataMaskAttr: '*[data-mask]',
@@ -457,13 +461,9 @@
     globals = $.jMaskGlobals = $.extend(true, {}, globals, $.jMaskGlobals);
     
     // looking for inputs with data-mask attribute
-    if (globals.dataMask) {            
-        $(globals.dataMaskAttr).each(HTMLAttributes);
-    }
+    if (globals.dataMask) { $.applyMasksFromHTML(); }
 
     setInterval(function(){
-        if ($.jMaskGlobals.watchDataMask) {
-            $(document).find($.jMaskGlobals.maskElements).filter(globals.dataMaskAttr).each(HTMLAttributes);
-        }
+        if ($.jMaskGlobals.watchDataMask) { $.applyMasksFromHTML(); }
     }, globals.watchInterval);
 }));


### PR DESCRIPTION
I use the UJS attributes. By default, the code masks all "data-mask" elements, but there's no function I can call to apply ones that were added to the DOM later (best I could do was calling .mask() on each one with the data-mask attributes). Now, I can call `$.applyMasksFromHTML();` after adding elements to the DOM, and they get applied.

I didn't like the idea of using the watcher because I know when they're being added, and could easily call it once and be done with it, which is why I added this.

I also noticed that the code that applies the initial data-mask masks uses ALL *[data-mask] fields, while the code that runs in the watcher only affects maskElements ('input,td,span,div'). That seemed inconsistent, so I made them both use this function which only affects maskElements.
