### PR TITLE
Change UMD wrapper to include CommonJS definition

### DIFF
--- a/dist/jquery.mask.js
+++ b/dist/jquery.mask.js
@@ -34,14 +34,11 @@
 /* global define */
 
 // UMD (Universal Module Definition) patterns for JavaScript modules that work everywhere.
-// https://github.com/umdjs/umd/blob/master/jqueryPluginCommonjs.js
+// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
 (function (factory) {
     if (typeof define === "function" && define.amd) {
         // AMD. Register as an anonymous module.
         define(["jquery"], factory);
-    } else if (typeof exports === 'object') {
-        // Node/CommonJS
-        factory(require('jquery'));
     } else {
         // Browser globals
         factory(window.jQuery || window.Zepto);
@@ -135,7 +132,7 @@
                 var maskChunks = [], translation, pattern, optional, recursive, oRecursive, r;
 
                 for (var i = 0; i < mask.length; i++) {
-                    translation = jMask.translation[mask.charAt(i)];
+                    translation = jMask.translation[mask[i]];
 
                     if (translation) {
                         
@@ -144,14 +141,14 @@
                         recursive = translation.recursive;
                         
                         if (recursive) {
-                            maskChunks.push(mask.charAt(i));
-                            oRecursive = {digit: mask.charAt(i), pattern: pattern};
+                            maskChunks.push(mask[i]);
+                            oRecursive = {digit: mask[i], pattern: pattern};
                         } else {
                             maskChunks.push(!optional && !recursive ? pattern : (pattern + "?"));
                         }
 
                     } else {
-                        maskChunks.push(mask.charAt(i).replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'));
+                        maskChunks.push(mask[i].replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'));
                     }
                 }
                 

--- a/dist/jquery.mask.js
+++ b/dist/jquery.mask.js
@@ -34,11 +34,14 @@
 /* global define */
 
 // UMD (Universal Module Definition) patterns for JavaScript modules that work everywhere.
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
+// https://github.com/umdjs/umd/blob/master/jqueryPluginCommonjs.js
 (function (factory) {
     if (typeof define === "function" && define.amd) {
         // AMD. Register as an anonymous module.
         define(["jquery"], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS
+        factory(require('jquery'));
     } else {
         // Browser globals
         factory(window.jQuery || window.Zepto);
@@ -132,7 +135,7 @@
                 var maskChunks = [], translation, pattern, optional, recursive, oRecursive, r;
 
                 for (var i = 0; i < mask.length; i++) {
-                    translation = jMask.translation[mask[i]];
+                    translation = jMask.translation[mask.charAt(i)];
 
                     if (translation) {
                         
@@ -141,14 +144,14 @@
                         recursive = translation.recursive;
                         
                         if (recursive) {
-                            maskChunks.push(mask[i]);
-                            oRecursive = {digit: mask[i], pattern: pattern};
+                            maskChunks.push(mask.charAt(i));
+                            oRecursive = {digit: mask.charAt(i), pattern: pattern};
                         } else {
                             maskChunks.push(!optional && !recursive ? pattern : (pattern + "?"));
                         }
 
                     } else {
-                        maskChunks.push(mask[i].replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'));
+                        maskChunks.push(mask.charAt(i).replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'));
                     }
                 }
                 

--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -34,14 +34,11 @@
 /* global define */
 
 // UMD (Universal Module Definition) patterns for JavaScript modules that work everywhere.
-// https://github.com/umdjs/umd/blob/master/jqueryPluginCommonjs.js
+// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
 (function (factory) {
     if (typeof define === "function" && define.amd) {
         // AMD. Register as an anonymous module.
         define(["jquery"], factory);
-    } else if (typeof exports === 'object') {
-        // Node/CommonJS
-        factory(require('jquery'));
     } else {
         // Browser globals
         factory(window.jQuery || window.Zepto);

--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -34,11 +34,14 @@
 /* global define */
 
 // UMD (Universal Module Definition) patterns for JavaScript modules that work everywhere.
-// https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
+// https://github.com/umdjs/umd/blob/master/jqueryPluginCommonjs.js
 (function (factory) {
     if (typeof define === "function" && define.amd) {
         // AMD. Register as an anonymous module.
         define(["jquery"], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS
+        factory(require('jquery'));
     } else {
         // Browser globals
         factory(window.jQuery || window.Zepto);


### PR DESCRIPTION
Changed the UMD wrapper to include CommonJS definition so that plugin can be packaging tools that use CommonJS type modules (ie. Browserify).

https://github.com/umdjs/umd/blob/master/jqueryPluginCommonjs.js