### PR TITLE
Update: fix bad behaviour on cloned elements

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -120,6 +120,10 @@
                 })
                 // select all text on focus
                 .on('focus.mask', function (e) {
+                    // in case masked element has been cloned with events
+                    // apply the same mask to the clone as well
+                    e.target !== el[0] && $(e.target).data('mask', new Mask(this, mask, options));
+                    
                     if (options.selectOnFocus === true) {
                         $(e.target).select();
                     }
@@ -165,7 +169,7 @@
                 return new RegExp(r);
             },
             destroyEvents: function() {
-                el.off(['keydown', 'keyup', 'paste', 'drop', 'blur', 'focusout', ''].join('.mask '));
+                el.off(['keydown', 'keyup', 'paste', 'drop', 'blur', 'focus', 'focusout', ''].join('.mask '));
             },
             val: function(v) {
                 var isInput = el.is('input'),


### PR DESCRIPTION

$(function(){

    $("#form1 .dateinput").mask("0000/00/00");

    $("#button").on("click", function(){
        $("#form1 .dateinput")
            .clone({ withDataAndEvents: true })
            .appendTo("#form2");
    });

});

In this example, the cloned date input appended to form2 will not display the mask, mostly because of the variable "el", which keeps the reference to the original input. As a workaround, my code contribution checks, on focus (as the mask works with events, so they need to be cloned as well), if the focus event target is the same original one, referenced in "el" var. If so, do nothing. If not, apply the same mask with the same options to the current event target, because its a clone. This way we can clone any masked element with no problems.