### PR TITLE
Just strip unwanted chars

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -275,8 +275,9 @@
                             }
                             m += offset;
                         } else if (translation.optional) {
-                            m += offset;
-                            v -= offset;
+                            // just skip char
+                            //m += offset;
+                            //v -= offset;
                         } else if (translation.fallback) {
                             buf[addMethod](translation.fallback);
                             m += offset;


### PR DESCRIPTION
When inputting illegal char in middle of string, all characters after it are discarded. This is unwanted behavior, I would just strip away unwanted ones.