### PR TITLE
fix name for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "jQuery-Mask-Plugin",
+  "name": "jquery-mask-plugin",
   "version": "1.11.4",
   "main": "dist/jquery.mask.js",
   "ignore": [


### PR DESCRIPTION
bower jQuery-Mask-Plugin#1.11.4 extract archive.tar.gz
bower jQuery-Mask-Plugin#1.11.4 EINVALID Failed to read /var/folders/1t/y1l91wl10c1dzz3682wqvnxh0000gn/T/moi/bower/jQuery-Mask-Plugin-5067-vic466/bower.json

Additional error details:
The name contains upper case letters

see https://github.com/bower/bower.json-spec#name