### PR TITLE
Add check to ensure that there are input elements before using them

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -360,7 +360,7 @@
                 // this is necessary, otherwise if the user submit the form
                 // and then press the "back" button, the autocomplete will erase
                 // the data. Works fine on IE9+, FF, Opera, Safari.
-                if ('oninput' in $('input')[0] === false && el.attr('autocomplete') === 'on') {
+                if ($('input').length && 'oninput' in $('input')[0] === false && el.attr('autocomplete') === 'on') {
                   el.attr('autocomplete', 'off');
                 }
 


### PR DESCRIPTION
If a form is dynamically generated there might not be any input elements available on the page when Mask is initialised, with the element being added after it has been initialised.

This commit simply checked to see if there are any input elements before they are used.