### PR TITLE
Fixes Issue #333

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -483,7 +483,14 @@
     // looking for inputs with data-mask attribute
     if (globals.dataMask) { $.applyDataMask(); }
 
-    setInterval(function(){
-        if ($.jMaskGlobals.watchDataMask) { $.applyDataMask(); }
-    }, globals.watchInterval);
+
+    /*
+        ISSUE: 333 - Moved setInterval into a conditional check, as an infinite timeout was being applied from the default
+        settings previously, also caching inside   $.maskWatchers for future reference.  N.B. Due to the nature of how
+        this scans HTML data attributes, this condition can NOT be tested.
+     */
+    if($.jMaskGlobals.watchDataMask){
+        $.maskWatchers.watchDataMask = setInterval($.applyDataMask,globals.watchInterval );
+    }
+
 }));


### PR DESCRIPTION
Fixes #333 

Due to the nature of the HTML attribute scanning an how the global settings can only be directly overridden by patching $ before the plugin in loaded i was unable to write any tests to check the truthy/falsy expression evaliations.

This change by default will prevent an infinite interval from being created everytime the plugin is loaded into the page.

This change MAY affect anyone who is directly hooking into watchDataMask and changing its value at runtime, as this will no longer result in an applyDataMask being called as the interval is no longer running.


Please feedback as appropriate.