### PR TITLE
Fix for div,span,td mask function

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -53,9 +53,9 @@
     var Mask = function (el, mask, options) {
         el = $(el);
 
-        var jMask = this, oldValue = el.val(), regexMask;
+        var jMask = this, oldValue = el.val() || el.text(), regexMask;
 
-        mask = typeof mask === 'function' ? mask(el.val(), undefined, el,  options) : mask;
+        mask = typeof mask === 'function' ? mask(el.val() || el.text(), undefined, el,  options) : mask;
 
         var p = {
             invalid: [],


### PR DESCRIPTION
Fix the value used to evaluate mask if mask is a function and the element is not an input (div, td, span)

The el.val() returns a value only if it's an input. In case of (i.e.) span it return a value of "" and the function doesn't receive the correct value.