### PR TITLE
Added a method to have access to a masked value without putting it in the DOM element

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -222,9 +222,9 @@
                     return p.callbacks(e);
                 }
             },
-            getMasked: function(skipMaskChars) {
+            getMasked: function(skipMaskChars, val) {
                 var buf = [],
-                    value = p.val(),
+                    value = val === undefined ? p.val() : val + '',
                     m = 0, maskLen = mask.length,
                     v = 0, valLen = value.length,
                     offset = 1, addMethod = 'push',
@@ -336,6 +336,11 @@
         // get value without mask
         jMask.getCleanVal = function() {
            return p.getMasked(true);
+        };
+
+        // get masked value without the value being in the input or element
+        jMask.getMaskedVal = function(val) {
+           return p.getMasked(false, val);
         };
 
        jMask.init = function(onlyMask) {
@@ -465,6 +470,10 @@
 
     $.fn.cleanVal = function() {
         return this.data('mask').getCleanVal();
+    };
+
+    $.fn.maskedVal = function(val) {
+        return this.data('mask').getMaskedVal(val);
     };
 
     $.applyDataMask = function(selector) {

--- a/test/jquery.mask.test.js
+++ b/test/jquery.mask.test.js
@@ -349,6 +349,13 @@ $(document).ready(function(){
     equal( testfield.cleanVal(), "123123123123123123");
   });
 
+  module('Masking a value programmatically');
+
+  test("when I get the masked value programmatically", function(){
+    testfield.mask('(00) 0000-0000');
+    typeTest("1299999999", testfield);
+    equal( testfield.maskedVal("3488888888"), "(34) 8888-8888");
+  });
 
   module('personalized settings')
 


### PR DESCRIPTION
Added maskedVal(val) method for programmatic access to getMasked with a passed value to mask.  This is useful when using jQuery-Mask-Plugin with angular, where it can be used in a formatter for ng-model.