### PR TITLE
Fix cursor jumping while editing in non-IE browsers

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -81,11 +81,17 @@
                     if (el.is(':focus')) {
                         var range, ctrl = el.get(0);
 
-                        range = ctrl.createTextRange();
-                        range.collapse(true);
-                        range.moveEnd('character', pos);
-                        range.moveStart('character', pos);
-                        range.select();
+                        // Firefox, WebKit, etc..
+                        if (ctrl.setSelectionRange) {
+                            ctrl.focus();
+                            ctrl.setSelectionRange(pos, pos);
+                        } else { // IE
+                            range = ctrl.createTextRange();
+                            range.collapse(true);
+                            range.moveEnd('character', pos);
+                            range.moveStart('character', pos);
+                            range.select();
+                        }
                     }
                 } catch (e) {}
             },


### PR DESCRIPTION
Uses HTMLInputElement.setSelectionRange if available, otherwise falls back to the current implementation.

There is good browser support for this method according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange). This fixes the behavior as described in at least #356.