### PR TITLE
Enable Zepto test and also add tests for jQuery 3.0.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,7 +28,8 @@ module.exports = function(grunt) {
             'http://localhost:9001/test/test-for-jquery-1.8.3.html',
             'http://localhost:9001/test/test-for-jquery-1.9.1.html',
             'http://localhost:9001/test/test-for-jquery-2.1.1.html',
-            // 'http://localhost:9001/test/test-for-zepto.html'
+            'http://localhost:9001/test/test-for-jquery-3.0.0.html',
+            'http://localhost:9001/test/test-for-zepto.html'
           ]
         }
       }

--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -32,13 +32,13 @@
  */
 
 /* jshint laxbreak: true */
-/* global define, jQuery, Zepto */
+/* global define */
 
 'use strict';
 
 // UMD (Universal Module Definition) patterns for JavaScript modules that work everywhere.
 // https://github.com/umdjs/umd/blob/master/jqueryPluginCommonjs.js
-(function (factory) {
+(function (factory, jQuery, Zepto) {
 
     if (typeof define === 'function' && define.amd) {
         define(['jquery'], factory);
@@ -519,4 +519,4 @@
             $.applyDataMask();
         }
     }, globals.watchInterval);
-}));
+}, window.jQuery, window.Zepto));

--- a/test/test-for-jquery-3.0.0.html
+++ b/test/test-for-jquery-3.0.0.html
@@ -1,11 +1,11 @@
 <html>
 <head>
-  <title>Zepto-Mask-Plugin UnitTesting</title>  
+  <title>jQuery-Mask-Plugin UnitTesting</title>
   <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.11.0.css" type="text/css" media="all">
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /> 
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>
-  <h1 id="qunit-header">Zepto-Mask-Plugin QUnit Tests</h1>
+  <h1 id="qunit-header">jQuery-Mask-Plugin QUnit Tests</h1>
   <h2 id="qunit-banner"></h2>
   <div id="qunit-testrunner-toolbar"></div>
   <h2 id="qunit-userAgent"></h2>
@@ -23,10 +23,9 @@
   <div id="container-dy-non-inputs"> </div>
   <!--/ testing area-->
 
-  <script type="text/javascript" src="zepto/zepto.min.js"></script>
-  <script type="text/javascript" src="zepto/data.js"></script>
+  <script type="text/javascript" src="http://code.jquery.com/jquery-3.0.0.min.js"></script>
   <script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.11.0.js"></script>
-
+  
   <script type="text/javascript" src="./sinon-1.10.3.js"></script>
   <script type="text/javascript" src="./sinon-qunit-1.0.0.js"></script>
 


### PR DESCRIPTION
This PR enables the Zepto tests. And also adds tests for jQuery `3.0.0`