### PR TITLE
Fix input value mangling when inserting before a static mask character

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -254,6 +254,7 @@
                     };
                 }
 
+                var lastUntranslatedMaskChar;
                 while (check()) {
                     var maskDigit = mask.charAt(m),
                         valDigit = value.charAt(v),
@@ -274,6 +275,11 @@
                                 }
                             }
                             m += offset;
+                        } else if (valDigit === lastUntranslatedMaskChar) {
+                            // matched the last untranslated (raw) mask character that we encountered
+                            // likely an insert offset the mask character from the last entry; fall
+                            // through and only increment v
+                            lastUntranslatedMaskChar = undefined
                         } else if (translation.optional) {
                             m += offset;
                             v -= offset;
@@ -292,6 +298,8 @@
 
                         if (valDigit === maskDigit) {
                             v += offset;
+                        } else {
+                            lastUntranslatedMaskChar = maskDigit
                         }
 
                         m += offset;

--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -279,7 +279,7 @@
                             // matched the last untranslated (raw) mask character that we encountered
                             // likely an insert offset the mask character from the last entry; fall
                             // through and only increment v
-                            lastUntranslatedMaskChar = undefined
+                            lastUntranslatedMaskChar = undefined;
                         } else if (translation.optional) {
                             m += offset;
                             v -= offset;
@@ -299,7 +299,7 @@
                         if (valDigit === maskDigit) {
                             v += offset;
                         } else {
-                            lastUntranslatedMaskChar = maskDigit
+                            lastUntranslatedMaskChar = maskDigit;
                         }
 
                         m += offset;


### PR DESCRIPTION
This patch fixes an issue where inserting a character to a masked input, before a static character in the mask, removed the end of the input value.

Consider an input field with the following mask: `000-09999`

For the initial input value, I type `13456789`, which gets masked to `134-56789`. I realize that I missed the 2, so I place my cursor between the 1 and 3 and type 2. The input now reads: `123-4`, with the `56789` portion removed.

The problem occurs in `getMask()`, which operates as follows:
1. The `123` matches the mask, so we march along.
2. The `4` does not match the mask character at this position (`-`), and there is no translation for the mask character, so the mask character is inserted.
3. The `4` is checked again, and this time matches the mask value (`0`), so we march along.
4. The input character `-` is encountered, and does not match the mask value (`9`), but the translation for the mask value is optional, so we continue along the mask but reset the input counter (`v`).
5. Step 4 repeats for the rest of the mask string.

This pull request introduces a fix to track the mask character encountered in step 2, and simply keep marching along the input value if we encounter it.

I'm not certain this is the right fix, so I hope the description of the problem can spur some thought. This at least works as expected for my trivial example. I didn't think too deeply about optional, fallback or recursive.