### PR TITLE
Fix Input Watchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "grunt": "~0.4.1",
+    "grunt": "^1.0.1",
     "grunt-contrib-connect": "*",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-qunit": "*",
@@ -29,5 +29,8 @@
     "jshint-stylish": "^1.0.0",
     "load-grunt-tasks": "^3.1.0",
     "time-grunt": "^1.0.0"
+  },
+  "scripts": {
+    "test": "grunt test"
   }
 }

--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -390,6 +390,7 @@
         jMask.init(!el.is('input'));
     };
 
+    $.maskWatchers = {};
     var HTMLAttributes = function () {
         var input = $(this),
             options = {},
@@ -451,6 +452,18 @@
         return this;
     };
 
+    $.mask = function(selector, mask, options) {
+        var globals = $.jMaskGlobals,
+            interval = globals.watchInterval;
+
+        clearInterval($.maskWatchers[selector]);
+        $.maskWatchers[selector] = setInterval(function(){
+            $(selector).mask(mask, options);
+        }, interval);
+
+        return $(selector).mask(mask, options);
+    };
+
     $.fn.masked = function(val) {
         return this.data('mask').getMaskedVal(val);
     };
@@ -462,6 +475,12 @@
                 dataMask.remove().removeData('mask');
             }
         });
+    };
+
+    $.unmask = function(selector) {
+        clearInterval($.maskWatchers[selector]);
+        delete $.maskWatchers[selector];
+        return $(selector).unmask();
     };
 
     $.fn.cleanVal = function() {

--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -390,7 +390,6 @@
         jMask.init(!el.is('input'));
     };
 
-    $.maskWatchers = {};
     var HTMLAttributes = function () {
         var input = $(this),
             options = {},
@@ -442,24 +441,13 @@
 
     $.fn.mask = function(mask, options) {
         options = options || {};
-        var selector = this.selector,
-            globals = $.jMaskGlobals,
-            interval = globals.watchInterval,
-            watchInputs = options.watchInputs || globals.watchInputs,
-            maskFunction = function() {
+        var maskFunction = function() {
                 if (notSameMaskObject(this, mask, options)) {
                     return $(this).data('mask', new Mask(this, mask, options));
                 }
             };
 
         $(this).each(maskFunction);
-
-        if (selector && selector !== '' && watchInputs) {
-            clearInterval($.maskWatchers[selector]);
-            $.maskWatchers[selector] = setInterval(function(){
-                $(document).find(selector).each(maskFunction);
-            }, interval);
-        }
         return this;
     };
 
@@ -468,8 +456,6 @@
     };
 
     $.fn.unmask = function() {
-        clearInterval($.maskWatchers[this.selector]);
-        delete $.maskWatchers[this.selector];
         return this.each(function() {
             var dataMask = $(this).data('mask');
             if (dataMask) {
@@ -493,7 +479,6 @@
         dataMaskAttr: '*[data-mask]',
         dataMask: true,
         watchInterval: 300,
-        watchInputs: true,
         useInput: eventSupported('input'),
         watchDataMask: false,
         byPassKeys: [9, 16, 17, 18, 36, 37, 38, 39, 40, 91],

--- a/test/jquery.mask.test.js
+++ b/test/jquery.mask.test.js
@@ -702,8 +702,8 @@ $(document).ready(function(){
 
     ticker = setInterval(write, 1000);
 
-    write();
     $('.c', $container).mask('00:00');
+    write();
     testIt()
   });
 });

--- a/test/jquery.mask.test.js
+++ b/test/jquery.mask.test.js
@@ -665,45 +665,4 @@ $(document).ready(function(){
     typeAndBlur(testfield, "1.000,00");
     equal( testfield.val(), "1.000,00" );
   });
-
-  module('dynamically loaded elements')
-  test('#non-inputs', function(){
-    expect(5);
-
-    var $container = $('#container-dy-non-inputs');
-    var clock = this.clock;
-    var ticker;
-    var tester;
-    var c = 0;
-
-    function write() {
-
-      if (c >= 5) {
-          clearInterval(ticker);
-          clearInterval(tester);
-          return;
-      }
-
-      c++;
-
-      $container.append('<div class="c">' + c + c + c + c + '</div>');
-      clock.tick(1000);
-    };
-
-    function testIt() {
-
-      var cs = $container.find('.c');
-      $.each(cs, function(k, field){
-        var t = k + 1;
-        equal($(field).text(), '' + t + t + ':' + t + t);
-        t++;
-      });
-    };
-
-    ticker = setInterval(write, 1000);
-
-    $('.c', $container).mask('00:00');
-    write();
-    testIt()
-  });
 });

--- a/test/jquery.mask.test.js
+++ b/test/jquery.mask.test.js
@@ -665,4 +665,45 @@ $(document).ready(function(){
     typeAndBlur(testfield, "1.000,00");
     equal( testfield.val(), "1.000,00" );
   });
+
+  module('dynamically loaded elements')
+  test('#non-inputs', function(){
+    expect(5);
+
+    var $container = $('#container-dy-non-inputs');
+    var clock = this.clock;
+    var ticker;
+    var tester;
+    var c = 0;
+
+    function write() {
+
+      if (c >= 5) {
+          clearInterval(ticker);
+          clearInterval(tester);
+          return;
+      }
+
+      c++;
+
+      $container.append('<div class="c">' + c + c + c + c + '</div>');
+      clock.tick(1000);
+    };
+
+    function testIt() {
+
+      var cs = $container.find('.c');
+      $.each(cs, function(k, field){
+        var t = k + 1;
+        equal($(field).text(), '' + t + t + ':' + t + t);
+        t++;
+      });
+    };
+
+    ticker = setInterval(write, 1000);
+
+    $.mask('#container-dy-non-inputs .c', '00:00');
+    write();
+    testIt()
+  });
 });


### PR DESCRIPTION
Fixes #481

The `.selector` property was deprecated in jQuery 1.7 and remove in 3.0, because of it's questionable reliability. https://api.jquery.com/selector/

The test that would have caught the breakage in jQuery 3.0 was written out of order, so it was not actually testing the watcher detecting dynamic elements.

Move the watcher functionality to a static interface that requires supplying the selector as a parameter.

**Changes:**

 - Fix the "dynamic element" test
 - Create a static watcher interface
 - Allow grunt to be run from the npm script