### PR TITLE
fixing cursor position error

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -216,13 +216,16 @@
                 if ($.inArray(keyCode, jMask.byPassKeys) === -1) {
                     var newVal   = p.getMasked(),
                         caretPos = p.getCaret();
+                     	caretPos = p.newcaret || caretPos;
 
                     setTimeout(function(caretPos, newVal) {
-                      p.setCaret(p.calculateCaretPosition(caretPos, newVal));
+                      p.setCaret(caretPos);
                     }, 10, caretPos, newVal);
 
                     p.val(newVal);
                     p.setCaret(caretPos);
+                    p.newcaret = null;
+                    
                     return p.callbacks(e);
                 }
             },
@@ -234,7 +237,8 @@
                     offset = 1, addMethod = 'push',
                     resetPos = -1,
                     lastMaskChar,
-                    check;
+                    check,
+                    caretPos = p.getCaret();
 
                 if (options.reverse) {
                     addMethod = 'unshift';
@@ -290,9 +294,15 @@
                         }
                         v += offset;
                     } else {
+                    	if (buf.length + 1 === caretPos && value.length !== caretPos + 1) {
+                      	p.newcaret = caretPos + 1;
+                      }
+                      
                         if (!skipMaskChars) {
                             buf[addMethod](maskDigit);
                         }
+                        
+                        
 
                         if (valDigit === maskDigit) {
                             v += offset;
@@ -538,4 +548,3 @@
         }
     }, globals.watchInterval);
 }, window.jQuery, window.Zepto));
-

--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -218,7 +218,7 @@
                         caretPos = p.getCaret();
                      	caretPos = p.newcaret || caretPos;
 
-                    setTimeout(function(caretPos, newVal) {
+                    setTimeout(function(caretPos) {
                       p.setCaret(caretPos);
                     }, 10, caretPos, newVal);
 


### PR DESCRIPTION
When removing characters sometimes the cursor goes to a wrong position, this patch its an attempt to fix that
 problem
123-123-456

highlight -456

type 789
result
123-123-879

same for removing character right after a mask character