### PR TITLE
dev: fix: Any occurance of Mask will push the cursor to one position …

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -256,15 +256,14 @@
                 var keyCode = el.data('mask-keycode');
 
                 if ($.inArray(keyCode, jMask.byPassKeys) === -1) {
-                    var newVal   = p.getMasked(),
-                        caretPos = p.getCaret();
+                    var newVal   = p.getMasked();
 
                     setTimeout(function() {
                       p.setCaret(p.calculateCaretPosition());
                     }, 10);
 
                     p.val(newVal);
-                    p.setCaret(caretPos);
+                    p.setCaret(newVal.length); //For cut/paste, you will return val+mask length
                     return p.callbacks(e);
                 }
             },
@@ -455,9 +454,8 @@
                 p.destroyEvents();
                 p.events();
 
-                var caret = p.getCaret();
                 p.val(p.getMasked());
-                p.setCaret(caret);
+                p.setCaret(p.getMasked().length);
             }
         };
 


### PR DESCRIPTION
…back (AKA Reverse)

Issue:
- Any occurance of Mask anywhere in the val() will push the input by one.
- Example:
If your mask is $('#div').mask('12/19'); (Credit card expiry), the value will become ('12/91') (Here after you enter 1, the cursor will move backward. Hence this fix will address the issue.

Fix Description:
- Basically this fix will make sure the cursor is at the end position of the val.
- For browsers, they don't support it, there is a graceful fallback

More details:
- Please refer to :  https://css-tricks.com/snippets/jquery/move-cursor-to-end-of-textarea-or-input/
- More info: https://stackoverflow.com/a/17780924/1625557