### PR TITLE
Fix for meteor include

### DIFF
--- a/package.js
+++ b/package.js
@@ -10,5 +10,4 @@ Package.onUse(function(api) {
   api.versionsFrom('1.2.1');
   api.use('ecmascript');
   api.addFiles('dist/jquery.mask.js');
-  api.addFiles('dist/jquery.mask.min.js');
-});
+},'client');


### PR DESCRIPTION
At the moment this package includes the library on both the client and the server. Should only be on the client.

Also the minified version is not needed.

Error thrown on server: "ReferenceError: window is not defined"