### PR TITLE
Isolated 'use strict' operator

### DIFF
--- a/dist/jquery.mask.js
+++ b/dist/jquery.mask.js
@@ -35,8 +35,6 @@
 /* jshint maxcomplexity:17 */
 /* global define */
 
-'use strict';
-
 // UMD (Universal Module Definition) patterns for JavaScript modules that work everywhere.
 // https://github.com/umdjs/umd/blob/master/jqueryPluginCommonjs.js
 (function (factory, jQuery, Zepto) {
@@ -50,6 +48,7 @@
     }
 
 }(function ($) {
+    'use strict';
 
     var Mask = function (el, mask, options) {
 

--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -49,7 +49,7 @@
 
 }(function ($) {
     'use strict';
-    
+
     var Mask = function (el, mask, options) {
 
         var p = {

--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -35,8 +35,6 @@
 /* jshint maxcomplexity:17 */
 /* global define */
 
-'use strict';
-
 // UMD (Universal Module Definition) patterns for JavaScript modules that work everywhere.
 // https://github.com/umdjs/umd/blob/master/templates/jqueryPlugin.js
 (function (factory, jQuery, Zepto) {
@@ -50,7 +48,8 @@
     }
 
 }(function ($) {
-
+    'use strict';
+    
     var Mask = function (el, mask, options) {
 
         var p = {


### PR DESCRIPTION
Hi!
First of all - thanks for such a cool plugin! :)

To the point:
This small fix will prevent next situation (which I've faced with): 
when plugin compressed into a js bundle alongside with other code, and not so advanced js uglifier/compressor used which doesn't strip 'use strict'; operator, it will affect entire bundle,
and if there is some code using features not allowed in strict mode (I know that this is bad, but anyway :) ) - all js dies :(

Thanks!