### PR TITLE
Resolving issues with Global settings and new addTranslation property.

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -417,8 +417,20 @@
             options = options || {};
 
             jMask.clearIfNotMatch  = $.jMaskGlobals.clearIfNotMatch;
-            jMask.byPassKeys       = $.jMaskGlobals.byPassKeys;
+
+            // Caso nenhuma definição foi feita nas Definições Globais pelo usuário, pega o padrão do plugin!
+            jMask.byPassKeys       = ('byPassKeys' in $.jMaskGlobals) ? $.jMaskGlobals.byPassKeys : globals.byPassKeys;
+
             jMask.translation      = $.extend({}, $.jMaskGlobals.translation, options.translation);
+
+            // Caso nenhuma definição foi feita nas Definições Globais pelo usuário, pega o padrão do plugin!
+            jMask.translation      = Object.keys(jMask.translation).length == 0 ? globals.translation : jMask.translation;
+
+            // addTranslation: Propriedade para Adicionar translation sem remover as definidas por padrão!
+            jMask.translation      = $.extend({}, jMask.translation, $.jMaskGlobals.addTranslation);
+
+            // Caso o usuário não tenha definido a propriedade, obtém o valor padrão do Plugin!
+            $.jMaskGlobals.useInput = ('useInput' in $.jMaskGlobals) ? $.jMaskGlobals.useInput : globals.useInput ;
 
             jMask = $.extend(true, {}, jMask, options);
 


### PR DESCRIPTION
Eu tinha tido problemas ao definir algumas propriedades globais, sendo que algumas se perdiam caso não fossem passadas novamente.
Quando se definia propriedades globais com o comando "$.jMaskGlobals = { ... }" as propriedades não passadas pra esse objeto eram removidas do Plugin causando erros. As propriedades byPassKeys, translation e useInput, eram as mais impactantes no código. E nessa alteração eu forço elas a serem recuperadas da variável "globals", caso não sejam achadas ao executar o comando "$.jMaskGlobals = { ... }".
Outra coisa foi adicionar uma funcionalidade, que verifica se a propriedade chamada addTranslation foi passada ao "$.jMaskGlobals" permitindo manter as translations padrões e adicionar novas translations, passando apenas elas.

Ex:
```
$.jMaskGlobals.addTranslation = { 'H': {pattern: /[a-fA-F]/} };
```
Internamente no plugin a propriedade translation terá:
```
{
  '0': {pattern: /\d/},
  '9': {pattern: /\d/, optional: true},
  '#': {pattern: /\d/, recursive: true},
  'A': {pattern: /[a-zA-Z0-9]/},
  'S': {pattern: /[a-zA-Z]/},
  'H': {pattern: /[a-fA-F]/}
}
```

Espero que seja útil...

[Editado]
Tinha feito o exemplo da chamada da propriedade addTranslation como mostrado logo mais abaixo, mas isso alterava todo o objeto, invés de adicionar apenas as propriedades necessárias. O correto é usar como no exemplo de cima, que alterei.
```
$.jMaskGlobals = {
  addTranslation: { 'H': {pattern: /[a-fA-F]/} }
};
```