### PR TITLE
Fix #507 - unmask() does not remove the "maxlength" attribute

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -549,6 +549,8 @@
             if (dataMask) {
                 dataMask.remove().removeData('mask');
             }
+            
+            $(this).removeAttr('maxlength');
         });
     };
 

--- a/test/jquery.mask.test.js
+++ b/test/jquery.mask.test.js
@@ -336,10 +336,10 @@ $(document).ready(function(){
   module('Removing of maxlength attribute');
   test("when I unmask", function(){
     testfield.mask('0000');
-    equal("4", testfield.attr('maxlength'));
+    equal(testfield.attr('maxlength'), "4");
     
     testfield.unmask();
-    equal(undefined, testfield.attr('maxlength'));
+    equal(testfield.attr('maxlength'), undefined);
   });
 
   module('Getting Unmasked Value');

--- a/test/jquery.mask.test.js
+++ b/test/jquery.mask.test.js
@@ -332,6 +332,15 @@ $(document).ready(function(){
     testfield.unmask()
     equal( testfield.val(), "1299999999");
   });
+    
+  module('Removing of maxlength attribute');
+  test("when I unmask", function(){
+    testfield.mask('0000');
+    equal("4", testfield.attr('maxlength'));
+    
+    testfield.unmask();
+    equal(undefined, testfield.attr('maxlength'));
+  });
 
   module('Getting Unmasked Value');
 


### PR DESCRIPTION
@igorescobar 

Fix #507 - unmask() does not remove the "maxlength" attribute