### PR TITLE
Fix onChange not firing when typing previous value

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -112,15 +112,15 @@
                     el.data('changed', true);
                 })
                 .on('blur.mask', function(){
-                    if (oldValue !== p.val() && !el.data('changed')) {
+                    if (focusValue !== p.val() && !el.data('changed')) {
                         el.trigger('change');
                     }
                     el.data('changed', false);
                 })
                 // it's very important that this callback remains in this position
-                // otherwhise oldValue it's going to work buggy
+                // otherwhise focusValue it's going to work buggy
                 .on('blur.mask', function() {
-                    oldValue = p.val();
+                    focusValue = p.val();
                 })
                 // select all text on focus
                 .on('focus.mask', function (e) {
@@ -377,6 +377,7 @@
                             options[name].apply(this, args);
                         }
                     };
+                oldValue = val;
 
                 callback('onChange', changed === true, defaultArgs);
                 callback('onKeyPress', changed === true, defaultArgs);
@@ -386,7 +387,7 @@
         };
 
         el = $(el);
-        var jMask = this, oldValue = p.val(), regexMask;
+        var jMask = this, focusValue = p.val(), oldValue = p.val(), regexMask;
 
         mask = typeof mask === 'function' ? mask(p.val(), undefined, el,  options) : mask;
 


### PR DESCRIPTION
The current implementation is not firing the onChange callback passed in
the options.

This happens because the oldValue variable is updated only on blur. With
this changes, two variables are used. One controls the value that the
element had when it got focus, and the other one is changed immediately
after every change.

Fiddle that reproduces the problem: https://jsfiddle.net/kp5hq1e8/7/
Steps to reproduce:
- Click on the input to give focus
- Type something (for example "1")
- Click somewhere else on the page so the input loses focus
- Click again on the input
- Type another value ("12")
- Type the previously typed value ("1")

It was expected that the onChange callback would be fired every time, but when entering the value that the input had when it lost focus nothing happens.

Output of the fiddle with the steps above:
- focus
- 1
- blur
- focus
- 12
- 12
- 12
- blur

Expected output:
- focus
- 1
- blur
- focus
- 12
- 1
- 12
- 1
- 12
- blur