### PR TITLE
Allow setting translation from HTML attribute

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -489,6 +489,15 @@
            options.selectOnFocus = true;
         }
 
+        var trans = input.attr(prefix + 'translation');
+        if (trans) {
+            try {
+                options.translation = JSON.parse(trans);
+            } catch (e) {
+                // data was bad, ignore it
+            }
+        }
+
         if (notSameMaskObject(input, mask, options)) {
             return input.data('mask', new Mask(this, mask, options));
         }


### PR DESCRIPTION
The value must be properly escaped for HTML, and the pattern cannot have surrounding slashes. Example: `data-mask-translation="{&quot;x&quot;:{&quot;pattern&quot;:&quot;[0-9a-fA-F]&quot;}}"`

See issue #675 