### PR TITLE
Fix issue preventing calculateCaretPosition from calculating correctly.

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -255,7 +255,7 @@
                 if ($.inArray(keyCode, jMask.byPassKeys) === -1) {
                     var newVal = p.getMasked(),
                         caretPos = p.getCaret(),
-                        oldVal = el.data('mask-previus-value');
+                        oldVal = el.data('mask-previus-value') || '';
 
                     // this is a compensation to devices/browsers that don't compensate
                     // caret positioning the right way

--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -187,9 +187,8 @@
 
                 return r;
             },
-            calculateCaretPosition: function() {
-                var oldVal = el.data('mask-previus-value') || '',
-                    newVal = p.getMasked(),
+            calculateCaretPosition: function(oldVal='') {
+                var newVal = p.getMasked(),
                     caretPosNew = p.getCaret();
                 if (oldVal !== newVal) {
                     var caretPosOld = el.data('mask-previus-caret-pos') || 0,
@@ -255,12 +254,13 @@
 
                 if ($.inArray(keyCode, jMask.byPassKeys) === -1) {
                     var newVal = p.getMasked(),
-                        caretPos = p.getCaret();
+                        caretPos = p.getCaret(),
+                        oldVal = el.data('mask-previus-value');
 
                     // this is a compensation to devices/browsers that don't compensate
                     // caret positioning the right way
                     setTimeout(function() {
-                      p.setCaret(p.calculateCaretPosition());
+                      p.setCaret(p.calculateCaretPosition(oldVal));
                     }, $.jMaskGlobals.keyStrokeCompensation);
 
                     p.val(newVal);

--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -187,7 +187,7 @@
 
                 return r;
             },
-            calculateCaretPosition: function(oldVal='') {
+            calculateCaretPosition: function(oldVal) {
                 var newVal = p.getMasked(),
                     caretPosNew = p.getCaret();
                 if (oldVal !== newVal) {


### PR DESCRIPTION
Since `calculateCaretPosition`  is being called in a timeout `el.data('mask-previus-value')` was being updated prior to `calculateCaretPosition`  executing. The net outcome of this was `oldVal === newVal`, so it'd never run anything inside the if statement on line 193.

This caused the issues in #602  to show up again, which is how I discovered this.

Fix is to just cache the oldVal when the timeout is created, and pass it in to the function directly.