### PR TITLE
static value test added

### DIFF
--- a/src/jquery.mask.js
+++ b/src/jquery.mask.js
@@ -130,7 +130,7 @@
                 })
                 // clear the value if it not complete the mask
                 .on('focusout.mask', function() {
-                    if (options.clearIfNotMatch && !regexMask.test(p.val())) {
+                    if (options.clearIfNotMatch && !testMaskedVal()) {
                        p.val('');
                    }
                 });
@@ -416,6 +416,10 @@
         jMask.getMaskedVal = function(val) {
            return p.getMasked(false, val);
         };
+        
+        jMask.testMaskedVal = function() {
+            return regexMask.test(p.val());
+        };
 
        jMask.init = function(onlyMask) {
             onlyMask = onlyMask || false;
@@ -561,6 +565,10 @@
     $.fn.cleanVal = function() {
         return this.data('mask').getCleanVal();
     };
+    
+    $.fn.maskMatched = function() {
+        return this.data('mask').testMaskedVal();
+    }
 
     $.applyDataMask = function(selector) {
         selector = selector || $.jMaskGlobals.maskElements;


### PR DESCRIPTION
Added `testMaskedVal` method that returns the result of `regexMask.test(p.val())`.

Added static method `maskMatched` that returns the result of `testMaskedVal` method.

Updated existing `focusout.mask` event to reference `testMaskedVal` method.